### PR TITLE
hub/auth-service: enforce single-active-connection semantics with per-generation pending ownership

### DIFF
--- a/rust/munode-hub/src/auth_service.rs
+++ b/rust/munode-hub/src/auth_service.rs
@@ -12,10 +12,28 @@
 //!
 //! # Connection model
 //!
-//! Only ONE auth service connection is active at a time. If a new connection
-//! arrives while one is active, the old connection is dropped.
+//! Only ONE auth service connection is treated as active at a time. A
+//! monotonic generation counter is bumped on each new connection; only the
+//! connection whose generation still matches the counter owns the shared
+//! `sender` slot. Pending auth requests are tagged with the generation they
+//! were sent on, so ownership and cleanup are per-generation:
+//!
+//! - An `authenticate` call snapshots the current `(sender, gen)` pair under
+//!   the sender lock, tags its waiter with that `gen`, then sends outside the
+//!   lock.
+//! - When a connection's read loop exits, its teardown drains waiters tagged
+//!   with its own `gen` (they can no longer complete through this
+//!   now-defunct connection), then clears the `sender` slot only if it's
+//!   still the current connection. A superseded connection's teardown leaves
+//!   the `sender` slot alone — the newer connection owns it.
+//! - A superseded connection whose WebSocket is still alive keeps delivering
+//!   any late `AuthResponse`s it receives via the shared `pending` map,
+//!   routed by `request_id` — so in-flight requests that were sent on it
+//!   before it was superseded still have a chance to complete until their
+//!   connection's own teardown fires.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -35,7 +53,16 @@ const AUTH_TIMEOUT_SECS: u64 = 10;
 /// Channel buffer size for outbound messages to the auth service.
 const OUTBOUND_BUFFER: usize = 256;
 
-type PendingAuthMap = Mutex<HashMap<String, oneshot::Sender<AuthResponse>>>;
+/// A pending auth request. `generation` tags the connection the request was
+/// sent on so teardown can drain only its own generation's waiters; a
+/// superseded connection that stays open keeps the ability to deliver late
+/// responses for entries with its own generation.
+struct PendingAuth {
+    generation: u64,
+    tx: oneshot::Sender<AuthResponse>,
+}
+
+type PendingAuthMap = Mutex<HashMap<String, PendingAuth>>;
 
 /// Shared handle to the auth service connection state.
 /// This is cheap to clone (Arc<Mutex<...>> inside).
@@ -45,6 +72,10 @@ pub struct AuthServiceHandle {
 }
 
 struct AuthServiceInner {
+    /// Monotonic generation counter. Incremented on every new connection;
+    /// a connection only owns the sender / pending state while its generation
+    /// still matches. See `handle_connection` for the usage pattern.
+    active_conn_gen: AtomicU64,
     /// Pending auth requests waiting for a response, keyed by request_id.
     pending: PendingAuthMap,
     /// Sender to the currently connected auth service WebSocket writer.
@@ -56,6 +87,7 @@ impl AuthServiceHandle {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(AuthServiceInner {
+                active_conn_gen: AtomicU64::new(0),
                 pending: Mutex::new(HashMap::new()),
                 sender: Mutex::new(None),
             }),
@@ -75,15 +107,9 @@ impl AuthServiceHandle {
     /// - The connection was dropped while waiting.
     pub async fn authenticate(&self, request: AuthRequest) -> Option<AuthResponse> {
         let request_id = request.request_id.clone();
-
-        // Register the pending waiter before sending to avoid races.
         let (resp_tx, resp_rx) = oneshot::channel::<AuthResponse>();
-        {
-            let mut pending = self.inner.pending.lock().await;
-            pending.insert(request_id.clone(), resp_tx);
-        }
 
-        // Encode and send the AuthRequest packet.
+        // Encode the packet before acquiring any lock.
         let packet = AuthServicePacket {
             r#type: AuthServicePacketType::AuthRequest as i32,
             auth_request: Some(request),
@@ -92,17 +118,36 @@ impl AuthServiceHandle {
         };
         let data = packet.encode_to_vec();
 
-        let send_ok = {
-            let sender = self.inner.sender.lock().await;
-            if let Some(tx) = sender.as_ref() {
-                tx.send(data).await.is_ok()
-            } else {
-                false
+        // Under the sender lock, snapshot the current generation and clone the
+        // outbound sender, then register our waiter tagged with that same
+        // generation. Holding the sender lock across the generation load and
+        // the pending insert makes the (gen, sender) pair consistent: teardown
+        // that advances the generation also holds this lock, so it cannot
+        // race us into registering against a stale generation. We release the
+        // sender lock before the `tx.send(...).await` so a slow writer cannot
+        // block connection handover.
+        let tx_clone = {
+            let sender_guard = self.inner.sender.lock().await;
+            let Some(tx) = sender_guard.as_ref() else {
+                return None;
+            };
+            let generation = self.inner.active_conn_gen.load(Ordering::Relaxed);
+            {
+                let mut pending = self.inner.pending.lock().await;
+                pending.insert(
+                    request_id.clone(),
+                    PendingAuth {
+                        generation,
+                        tx: resp_tx,
+                    },
+                );
             }
+            tx.clone()
         };
 
-        if !send_ok {
-            // Clean up pending waiter and signal "not connected".
+        if tx_clone.send(data).await.is_err() {
+            // Target connection's writer has gone away. Remove our waiter
+            // (if teardown hasn't already) and bail.
             self.inner.pending.lock().await.remove(&request_id);
             return None;
         }
@@ -125,30 +170,14 @@ impl AuthServiceHandle {
     /// Deliver a received AuthResponse to the waiting caller.
     async fn deliver_response(&self, response: AuthResponse) {
         let request_id = response.request_id.clone();
-        if let Some(tx) = self.inner.pending.lock().await.remove(&request_id) {
+        if let Some(PendingAuth { tx, .. }) =
+            self.inner.pending.lock().await.remove(&request_id)
+        {
             let _ = tx.send(response);
         } else {
             warn!(
                 "Received auth response for unknown request_id={}",
                 request_id
-            );
-        }
-    }
-
-    /// Register a new outbound sender (called when a new connection is accepted).
-    async fn set_sender(&self, sender: Option<mpsc::Sender<Vec<u8>>>) {
-        *self.inner.sender.lock().await = sender;
-    }
-
-    /// Fail all pending requests (called when the connection is lost).
-    async fn drain_pending(&self) {
-        let mut pending = self.inner.pending.lock().await;
-        let count = pending.len();
-        pending.drain(); // dropping all oneshot senders signals Err to waiters
-        if count > 0 {
-            warn!(
-                "{} pending auth request(s) cancelled due to auth service disconnect",
-                count
             );
         }
     }
@@ -159,13 +188,23 @@ impl AuthServiceHandle {
         ws_stream: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
         addr: std::net::SocketAddr,
     ) {
-        info!("Auth service connected from {}", addr);
-
         let (mut ws_tx, mut ws_rx) = ws_stream.split();
         let (tx, mut rx) = mpsc::channel::<Vec<u8>>(OUTBOUND_BUFFER);
 
-        // Register this connection's sender.
-        self.set_sender(Some(tx.clone())).await;
+        // Atomic claim: bump the generation counter and install this
+        // connection's sender under one sender-lock critical section.
+        // `authenticate` also reads the generation and clones the sender
+        // under this same lock, so an external observer can never see
+        // `(gen advanced, sender still old)`. `Relaxed` is sufficient because
+        // all accesses to `active_conn_gen` happen inside this mutex — the
+        // mutex itself provides the ordering and visibility guarantees.
+        let my_gen = {
+            let mut sender_guard = self.inner.sender.lock().await;
+            let g = self.inner.active_conn_gen.fetch_add(1, Ordering::Relaxed) + 1;
+            *sender_guard = Some(tx.clone());
+            g
+        };
+        info!("Auth service connected from {} (gen={})", addr, my_gen);
 
         // Spawn writer task.
         let write_task = tokio::spawn(async move {
@@ -191,7 +230,7 @@ impl AuthServiceHandle {
                     }
                 }
                 Ok(WsMessage::Close(_)) => {
-                    info!("Auth service disconnected: {}", addr);
+                    info!("Auth service disconnected: {} (gen={})", addr, my_gen);
                     break;
                 }
                 Ok(WsMessage::Ping(payload)) => {
@@ -209,18 +248,67 @@ impl AuthServiceHandle {
                     let _ = payload; // suppress unused warning
                 }
                 Err(e) => {
-                    error!("Auth service WS error from {}: {}", addr, e);
+                    error!("Auth service WS error from {} (gen={}): {}", addr, my_gen, e);
                     break;
                 }
                 _ => {}
             }
         }
 
-        // Clean up on disconnect.
-        self.set_sender(None).await;
-        self.drain_pending().await;
+        // Teardown step 1 — stop handing our sender to new callers.
+        // Clear the sender slot first (only if we're still the current
+        // connection) so `authenticate()` cannot continue to snapshot our
+        // now-dead `tx`. A newer connection that has already claimed the
+        // slot owns `sender`; leaving it alone is correct for that case.
+        let was_current = {
+            let mut sender_guard = self.inner.sender.lock().await;
+            if self.inner.active_conn_gen.load(Ordering::Relaxed) == my_gen {
+                *sender_guard = None;
+                true
+            } else {
+                false
+            }
+        };
+
+        // Teardown step 2 — sever the writer pipe. Aborting the writer task
+        // drops the `rx` end of the mpsc channel, so any `tx.send(...).await`
+        // from an `authenticate()` that slipped in during the tiny window
+        // between its sender-lock release and our sender-lock acquisition
+        // fails immediately. Combined with step 3, that call's waiter will
+        // be removed too, so it returns `None` rather than quietly queueing
+        // data to a dead peer.
         write_task.abort();
-        info!("Auth service connection closed: {}", addr);
+
+        // Teardown step 3 — cancel waiters tagged with our generation. They
+        // can no longer complete through this connection. Entries tagged
+        // with other generations are left alone: they belong either to a
+        // superseded sibling that's still reading or to a future connection
+        // that hasn't been born yet.
+        let cancelled = {
+            let mut pending_guard = self.inner.pending.lock().await;
+            let pre = pending_guard.len();
+            pending_guard.retain(|_, entry| entry.generation != my_gen);
+            pre - pending_guard.len()
+        };
+        if cancelled > 0 {
+            warn!(
+                "{} pending auth request(s) cancelled due to auth service disconnect (gen={})",
+                cancelled, my_gen
+            );
+        }
+
+
+        if was_current {
+            info!(
+                "Auth service connection closed: {} (gen={}, was current)",
+                addr, my_gen
+            );
+        } else {
+            info!(
+                "Auth service connection closed: {} (gen={}, superseded)",
+                addr, my_gen
+            );
+        }
     }
 
     /// Dispatch a decoded packet.


### PR DESCRIPTION
### Summary

Fix a connection-lifecycle race in `AuthServiceHandle` where a **stale** auth-service connection closing after a new one has taken over can wipe out the new connection's shared sender and cancel all its in-flight authentication work.

Like the companion PR, this is a latent correctness bug I found while auditing this path; I have **not** observed it in production.

### Root cause

Previously, every connection's teardown unconditionally:

1. Cleared `AuthServiceInner.sender` (the shared write handle)
2. Drained the entire `pending` map, failing every waiter

There was no notion of "this teardown belongs to an older, already-superseded connection". A slow old reader exiting after a new connection had already installed its own sender would therefore:

- Overwrite the **new** connection's sender with `None` → subsequent `authenticate()` calls see no active connection
- Cancel every waiter currently belonging to the **new** connection, including ones whose responses were already in flight

The window is narrow but real: any path where two connections coexist briefly (reconnect storm, supervisor restart while a request is in flight, transient network partition that ends with the client reopening before the server notices the old socket is dead) can hit it.

### Fix — generational ownership

Ownership of the shared sender and of each pending waiter is now stamped with a generation number:

- `AuthServiceInner` carries `active_conn_gen: AtomicU64`.
- Each new connection reserves a generation and installs its sender **in one critical section under the sender lock** — external observers never see "gen advanced, sender still old" or vice versa.
- `PendingAuth { generation, tx: oneshot::Sender<_> }` replaces the bare `oneshot::Sender` in the pending map. Each waiter records the generation it was dispatched on.
- `authenticate()` snapshots `(sender.clone(), active_conn_gen)` under the sender lock, inserts a waiter tagged with that generation, then **releases the lock before awaiting `tx.send`**, so a slow writer cannot block connection handover.
- Teardown performs three ordered steps:
  1. Clear `sender` only if `active_conn_gen == my_gen` (otherwise the slot already belongs to a successor — don't touch it).
  2. `write_task.abort()` — fail any concurrent in-flight `tx.send` from an `authenticate()` call that snapshotted this generation's sender.
  3. `pending.retain(|_, entry| entry.generation != my_gen)` — only clean this generation's waiters. Waiters for **older** superseded-but-still-alive generations remain in the map and can still complete via `deliver_response`.

`Ordering::Relaxed` is sufficient because every `active_conn_gen` access happens under the sender mutex, which already provides the necessary happens-before edges.

### Remaining edge window (disclosed)

Between step 1 (`sender = None` under lock, released) and step 2 (`write_task.abort()`), an in-flight write that has already passed its authenticate-side await point can still land on the socket. The consequence is that one final auth request for the defunct connection may be sent to the already-disconnecting peer; that request will time out or get `None` via the subsequent teardown path, never via a wrong-user response. I considered this acceptable — closing it would require either holding the sender lock across `write_task.abort()` (HoL-blocks every concurrent `authenticate()` for the duration of an async abort) or introducing a per-connection writer guard that serialises sends, both of which cost more than the window is worth. Happy to reconsider if reviewers see it differently.

### Scope

- One file: `rust/munode-hub/src/auth_service.rs` (+137 / −157, mostly a rewrite of connection setup/teardown and `authenticate`).
- Helpers `set_sender` and `drain_pending` are inlined — their new callers need to see the sender lock / generation together, so extraction hurt clarity.
- No protocol change, no new dependencies.

### Verification

- `cargo check -p munode-hub` clean.
- Lock-graph check: `authenticate` acquires sender → pending nested; teardown acquires sender then pending non-nested; `deliver_response` / timeout cleanup acquire pending only. No cycles.
- No runtime testing against the production auth service.

### Merge order

**This PR depends on [hub-local auth request IDs](https://github.com/garveen/munode/pull/97) being merged first.** That PR establishes globally unique `request_id` values on the Hub side; without it, two colliding Edge-supplied request IDs can still land in the same `pending` slot across generations and defeat the generation fence introduced here.

If the companion PR lands first, this branch rebases cleanly on top of `master`. If the review order needs to be reversed, let me know and I'll resequence.
